### PR TITLE
Fix hardcoded protobuf package references in generated code

### DIFF
--- a/core/src/main/scala/fastproto/ProtoToRowGenerator.scala
+++ b/core/src/main/scala/fastproto/ProtoToRowGenerator.scala
@@ -296,7 +296,7 @@ object ProtoToRowGenerator {
           code ++= s"    UnsafeArrayWriter arrayWriter = new UnsafeArrayWriter(writer, 8);\n"
           code ++= s"    arrayWriter.initialize(count);\n"
           code ++= s"    for (int i = 0; i < count; i++) {\n"
-          code ++= s"      com.google.protobuf.ByteString bs = msg.${getBytesMethodName}(i);\n"
+          code ++= s"      ${classOf[ByteString].getName} bs = msg.${getBytesMethodName}(i);\n"
           code ++= s"      byte[] bytes = bs.toByteArray();\n"
           code ++= s"      arrayWriter.write(i, bytes);\n"
           code ++= s"    }\n"
@@ -647,7 +647,7 @@ object ProtoToRowGenerator {
       case FieldDescriptor.JavaType.DOUBLE => "Double"
       case FieldDescriptor.JavaType.BOOLEAN => "Boolean"
       case FieldDescriptor.JavaType.STRING => "String"
-      case FieldDescriptor.JavaType.BYTE_STRING => "com.google.protobuf.ByteString"
+      case FieldDescriptor.JavaType.BYTE_STRING => classOf[ByteString].getName
       case FieldDescriptor.JavaType.ENUM => fd.getEnumType.getName
       case FieldDescriptor.JavaType.MESSAGE => fd.getMessageType.getName
     }

--- a/core/src/main/scala/fastproto/WireFormatToRowGenerator.scala
+++ b/core/src/main/scala/fastproto/WireFormatToRowGenerator.scala
@@ -361,8 +361,8 @@ object WireFormatToRowGenerator {
     val code = new StringBuilder
 
     // Imports
-    code ++= "import com.google.protobuf.CodedInputStream;\n"
-    code ++= "import com.google.protobuf.WireFormat;\n"
+    code ++= s"import ${classOf[com.google.protobuf.CodedInputStream].getName};\n"
+    code ++= s"import ${classOf[WireFormat].getName};\n"
     code ++= "import org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter;\n"
     code ++= "import org.apache.spark.sql.types.StructType;\n"
     code ++= "import org.apache.spark.unsafe.types.UTF8String;\n"


### PR DESCRIPTION
## Summary

- Replace hardcoded `"com.google.protobuf"` package references with runtime class name resolution using `classOf[].getName`
- Ensures generated code works correctly with shaded protobuf dependencies
- Fixes compatibility when protobuf classes are relocated to different packages at runtime

## Changes

**ProtoToRowGenerator.scala:**
- Line 299: Use `${classOf[ByteString].getName}` instead of hardcoded string in repeated string field code generation
- Line 650: Use `classOf[ByteString].getName` in `getJavaTypeString` method

**WireFormatToRowGenerator.scala:**
- Lines 364-365: Use `classOf[].getName` for dynamic import generation instead of hardcoded import strings

## Test Plan

- [x] Project compiles successfully
- [x] All existing tests pass
- [x] Generated code now uses runtime class names instead of hardcoded package references

🤖 Generated with [Claude Code](https://claude.ai/code)