### PR TITLE
WireFormatParser Recursive Parsing Support

### DIFF
--- a/bench/src/test/scala/org/apache/spark/sql/protobuf/backport/jmh/ProtobufConversionJmhBenchmarkDom.scala
+++ b/bench/src/test/scala/org/apache/spark/sql/protobuf/backport/jmh/ProtobufConversionJmhBenchmarkDom.scala
@@ -3,7 +3,7 @@ package org.apache.spark.sql.protobuf.backport.jmh
 import benchmark.DomBenchmarkProtos.DomDocument
 import benchmark.DomTestDataGenerator
 import com.google.protobuf.{DescriptorProtos, Descriptors}
-import fastproto.{Parser, ProtoToRowGenerator, RecursiveSchemaConverters, StreamWireParser, WireFormatParser, WireFormatToRowGenerator}
+import fastproto._
 import org.apache.spark.sql.types._
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
@@ -39,9 +39,9 @@ import java.util.concurrent.TimeUnit
 class ProtobufConversionJmhBenchmarkDom {
 
   // Test data with different complexity levels
-  var shallowDomBinary: Array[Byte] = _     // depth=3, breadth=2
-  var standardDomBinary: Array[Byte] = _    // depth=6, breadth=3
-  var deepDomBinary: Array[Byte] = _        // depth=8, breadth=4
+  var shallowDomBinary: Array[Byte] = _ // depth=3, breadth=2
+  var standardDomBinary: Array[Byte] = _ // depth=6, breadth=3
+  var deepDomBinary: Array[Byte] = _ // depth=8, breadth=4
 
   // Descriptors and schemas
   var domDescriptor: Descriptors.Descriptor = _
@@ -52,7 +52,7 @@ class ProtobufConversionJmhBenchmarkDom {
   // Parsers for DOM structure (using standard complexity)
   var domDirectParser: WireFormatParser = _
   var domGeneratedWireParser: StreamWireParser = _
-  var domProtoToRowParser: Parser = _  // ProtoToRowGenerator produces parsers that implement Parser
+  var domProtoToRowParser: Parser = _ // ProtoToRowGenerator produces parsers that implement Parser
   // var domDynamicParser: DynamicMessageParser = _
 
   @Setup
@@ -163,7 +163,7 @@ class ProtobufConversionJmhBenchmarkDom {
     bh.consume(domGeneratedWireParser.parse(deepDomBinary))
   }
 
-  @Benchmark
+  // @Benchmark
   def domDeepProtoToRowParser(bh: Blackhole): Unit = {
     bh.consume(domProtoToRowParser.parse(deepDomBinary))
   }
@@ -171,6 +171,11 @@ class ProtobufConversionJmhBenchmarkDom {
   @Benchmark
   def domDeepDirectWireFormatParser(bh: Blackhole): Unit = {
     bh.consume(domDirectParser.parse(deepDomBinary))
+  }
+
+  @Benchmark
+  def domDeepProtoParsing(bh: Blackhole): Unit = {
+    bh.consume(DomDocument.parseFrom(deepDomBinary))
   }
 
   // @Benchmark

--- a/bench/src/test/scala/org/apache/spark/sql/protobuf/backport/jmh/ProtobufConversionJmhBenchmarkDom.scala
+++ b/bench/src/test/scala/org/apache/spark/sql/protobuf/backport/jmh/ProtobufConversionJmhBenchmarkDom.scala
@@ -3,7 +3,7 @@ package org.apache.spark.sql.protobuf.backport.jmh
 import benchmark.DomBenchmarkProtos.DomDocument
 import benchmark.DomTestDataGenerator
 import com.google.protobuf.{DescriptorProtos, Descriptors}
-import fastproto.{Parser, ProtoToRowGenerator, RecursiveSchemaConverters, StreamWireParser, WireFormatToRowGenerator}
+import fastproto.{Parser, ProtoToRowGenerator, RecursiveSchemaConverters, StreamWireParser, WireFormatParser, WireFormatToRowGenerator}
 import org.apache.spark.sql.types._
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
@@ -50,7 +50,7 @@ class ProtobufConversionJmhBenchmarkDom {
   var domTempDescFile: java.io.File = _
 
   // Parsers for DOM structure (using standard complexity)
-  // var domDirectParser: WireFormatParser = _
+  var domDirectParser: WireFormatParser = _
   var domGeneratedWireParser: StreamWireParser = _
   var domProtoToRowParser: Parser = _  // ProtoToRowGenerator produces parsers that implement Parser
   // var domDynamicParser: DynamicMessageParser = _
@@ -94,7 +94,7 @@ class ProtobufConversionJmhBenchmarkDom {
     domTempDescFile.deleteOnExit()
 
     // === Initialize DOM Parsers ===
-    // domDirectParser = new WireFormatParser(domDescriptor, domSparkSchema)
+    domDirectParser = new WireFormatParser(domDescriptor, domSparkSchema)
     domGeneratedWireParser = WireFormatToRowGenerator.generateParser(domDescriptor, domSparkSchema)
     domProtoToRowParser = ProtoToRowGenerator.generateParser(domDescriptor, classOf[DomDocument], domSparkSchema)
     // domDynamicParser = new DynamicMessageParser(domDescriptor, domSparkSchema)
@@ -168,10 +168,10 @@ class ProtobufConversionJmhBenchmarkDom {
     bh.consume(domProtoToRowParser.parse(deepDomBinary))
   }
 
-  // @Benchmark
-  // def domDeepDirectWireFormatParser(bh: Blackhole): Unit = {
-  //   bh.consume(domDirectParser.parse(deepDomBinary))
-  // }
+  @Benchmark
+  def domDeepDirectWireFormatParser(bh: Blackhole): Unit = {
+    bh.consume(domDirectParser.parse(deepDomBinary))
+  }
 
   // @Benchmark
   // def domDeepDynamicMessageParser(bh: Blackhole): Unit = {

--- a/bench/src/test/scala/org/apache/spark/sql/protobuf/backport/jmh/ProtobufConversionJmhBenchmarkSimple.scala
+++ b/bench/src/test/scala/org/apache/spark/sql/protobuf/backport/jmh/ProtobufConversionJmhBenchmarkSimple.scala
@@ -1,6 +1,6 @@
 package org.apache.spark.sql.protobuf.backport.jmh
 
-import benchmark.TestDataGenerator
+import benchmark.{SimpleBenchmarkProtos, TestDataGenerator}
 import com.google.protobuf.{DescriptorProtos, Descriptors}
 import fastproto.{StreamWireParser, WireFormatParser, WireFormatToRowGenerator}
 import org.apache.spark.sql.protobuf.backport.DynamicMessageParser
@@ -91,5 +91,10 @@ class ProtobufConversionJmhBenchmarkSimple {
   // @Benchmark
   def simpleDynamicMessageParser(bh: Blackhole): Unit = {
     bh.consume(simpleDynamicParser.parse(simpleBinary))
+  }
+
+  @Benchmark
+  def simpleProtoParsing(bh: Blackhole): Unit = {
+    bh.consume(SimpleBenchmarkProtos.SimpleMessage.parser().parseFrom(simpleBinary))
   }
 }

--- a/core/src/main/java/fastproto/BooleanList.java
+++ b/core/src/main/java/fastproto/BooleanList.java
@@ -4,11 +4,8 @@ package fastproto;
  * Efficient growable boolean array for packed repeated field parsing.
  * Uses public fields for performance and direct access in generated code.
  */
-public class BooleanList {
+public class BooleanList extends FastList {
     public boolean[] array;
-    public int count;
-
-    private static final int DEFAULT_CAPACITY = 10;
 
     public BooleanList() {
         this.array = new boolean[DEFAULT_CAPACITY];

--- a/core/src/main/java/fastproto/BufferList.java
+++ b/core/src/main/java/fastproto/BufferList.java
@@ -8,46 +8,9 @@ import java.nio.ByteBuffer;
  * Optimized for ByteBuffer accumulation to avoid data copying for nested messages.
  * This avoids generic overhead compared to GenericList<ByteBuffer>.
  */
-public class BufferList extends FastList {
-    public ByteBuffer[] array;
-
-    public BufferList() {
-        this.array = new ByteBuffer[DEFAULT_CAPACITY];
-        this.count = 0;
-    }
-
-    /**
-     * Ensure capacity for at least minCapacity elements.
-     * Preserves existing data up to current count.
-     */
-    public void sizeHint(int minCapacity) {
-        if (array.length < minCapacity) {
-            int newCapacity = Math.max(array.length * 2, minCapacity);
-            ByteBuffer[] newArray = new ByteBuffer[newCapacity];
-            System.arraycopy(array, 0, newArray, 0, count);
-            array = newArray;
-        }
-    }
-
-    /**
-     * Grow array capacity, using currentCount for data preservation.
-     * Called during parsing when we've already updated local count.
-     */
-    public void grow(int currentCount) {
-        int newCapacity = array.length * 2;
-        ByteBuffer[] newArray = new ByteBuffer[newCapacity];
-        System.arraycopy(array, 0, newArray, 0, currentCount);
-        array = newArray;
-    }
-
-    /**
-     * Add a single ByteBuffer to the list, growing if necessary.
-     * Used for repeated message field values.
-     */
-    public void add(ByteBuffer value) {
-        if (count >= array.length) {
-            grow(count);
-        }
-        array[count++] = value;
+public class BufferList extends ObjectList<ByteBuffer> {
+    @Override
+    protected ByteBuffer[] newArray(int len) {
+        return new ByteBuffer[len];
     }
 }

--- a/core/src/main/java/fastproto/BufferList.java
+++ b/core/src/main/java/fastproto/BufferList.java
@@ -1,0 +1,53 @@
+package fastproto;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Specialized growable ByteBuffer list for repeated message field parsing.
+ * Uses public fields for performance and direct access in generated code.
+ * Optimized for ByteBuffer accumulation to avoid data copying for nested messages.
+ * This avoids generic overhead compared to GenericList<ByteBuffer>.
+ */
+public class BufferList extends FastList {
+    public ByteBuffer[] array;
+
+    public BufferList() {
+        this.array = new ByteBuffer[DEFAULT_CAPACITY];
+        this.count = 0;
+    }
+
+    /**
+     * Ensure capacity for at least minCapacity elements.
+     * Preserves existing data up to current count.
+     */
+    public void sizeHint(int minCapacity) {
+        if (array.length < minCapacity) {
+            int newCapacity = Math.max(array.length * 2, minCapacity);
+            ByteBuffer[] newArray = new ByteBuffer[newCapacity];
+            System.arraycopy(array, 0, newArray, 0, count);
+            array = newArray;
+        }
+    }
+
+    /**
+     * Grow array capacity, using currentCount for data preservation.
+     * Called during parsing when we've already updated local count.
+     */
+    public void grow(int currentCount) {
+        int newCapacity = array.length * 2;
+        ByteBuffer[] newArray = new ByteBuffer[newCapacity];
+        System.arraycopy(array, 0, newArray, 0, currentCount);
+        array = newArray;
+    }
+
+    /**
+     * Add a single ByteBuffer to the list, growing if necessary.
+     * Used for repeated message field values.
+     */
+    public void add(ByteBuffer value) {
+        if (count >= array.length) {
+            grow(count);
+        }
+        array[count++] = value;
+    }
+}

--- a/core/src/main/java/fastproto/DoubleList.java
+++ b/core/src/main/java/fastproto/DoubleList.java
@@ -4,11 +4,8 @@ package fastproto;
  * Efficient growable double array for packed repeated field parsing.
  * Uses public fields for performance and direct access in generated code.
  */
-public class DoubleList {
+public class DoubleList extends FastList {
     public double[] array;
-    public int count;
-
-    private static final int DEFAULT_CAPACITY = 10;
 
     public DoubleList() {
         this.array = new double[DEFAULT_CAPACITY];

--- a/core/src/main/java/fastproto/FastList.java
+++ b/core/src/main/java/fastproto/FastList.java
@@ -1,0 +1,17 @@
+package fastproto;
+
+public abstract class FastList {
+    public int count;
+
+    protected static final int DEFAULT_CAPACITY = 10;
+
+    public void reset() {
+        count = 0;
+    }
+
+    public abstract void sizeHint(int minCapacity);
+
+    public abstract void grow(int currentCount);
+
+    // no common `add` method to avoid boxing
+}

--- a/core/src/main/java/fastproto/FloatList.java
+++ b/core/src/main/java/fastproto/FloatList.java
@@ -4,11 +4,8 @@ package fastproto;
  * Efficient growable float array for packed repeated field parsing.
  * Uses public fields for performance and direct access in generated code.
  */
-public class FloatList {
+public class FloatList extends FastList {
     public float[] array;
-    public int count;
-
-    private static final int DEFAULT_CAPACITY = 10;
 
     public FloatList() {
         this.array = new float[DEFAULT_CAPACITY];

--- a/core/src/main/java/fastproto/GenericList.java
+++ b/core/src/main/java/fastproto/GenericList.java
@@ -1,5 +1,7 @@
 package fastproto;
 
+import java.lang.reflect.Array;
+
 /**
  * Generic growable list for repeated field parsing.
  * Uses public fields for performance and direct access in generated code.
@@ -7,9 +9,23 @@ package fastproto;
  * to avoid data copying for nested messages.
  */
 public class GenericList<T> extends ObjectList<T> {
+    private final Class<T> elementClass;
+
+    public GenericList(Class<T> elementClass) {
+        super(false); // Don't initialize in parent constructor
+        if (elementClass == null) {
+            throw new IllegalArgumentException("elementClass cannot be null");
+        }
+        this.elementClass = elementClass;
+        // Now initialize manually
+        this.array = newArray(DEFAULT_CAPACITY);
+        this.count = 0;
+    }
+
     @Override
     @SuppressWarnings("unchecked")
     protected T[] newArray(int len) {
-        return (T[]) new Object[len];
+        return (T[]) Array.newInstance(elementClass, len);
     }
+
 }

--- a/core/src/main/java/fastproto/GenericList.java
+++ b/core/src/main/java/fastproto/GenericList.java
@@ -1,0 +1,15 @@
+package fastproto;
+
+/**
+ * Generic growable list for repeated field parsing.
+ * Uses public fields for performance and direct access in generated code.
+ * Can hold any object type T, used primarily for ByteBuffer accumulation
+ * to avoid data copying for nested messages.
+ */
+public class GenericList<T> extends ObjectList<T> {
+    @Override
+    @SuppressWarnings("unchecked")
+    protected T[] newArray(int len) {
+        return (T[]) new Object[len];
+    }
+}

--- a/core/src/main/java/fastproto/GrowableArrayWriter.java
+++ b/core/src/main/java/fastproto/GrowableArrayWriter.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fastproto;
+
+import org.apache.spark.sql.catalyst.expressions.codegen.UnsafeWriter;
+import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.unsafe.Platform;
+import org.apache.spark.unsafe.array.ByteArrayMethods;
+import org.apache.spark.unsafe.bitset.BitSetMethods;
+
+import static org.apache.spark.sql.catalyst.expressions.UnsafeArrayData.calculateHeaderPortionInBytes;
+
+/**
+ * A helper class to write data into global row buffer using `UnsafeArrayData` format,
+ * used by {@link org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection}.
+ */
+public final class GrowableArrayWriter extends UnsafeWriter {
+
+  // The number of elements in this array
+  private int numElements;
+
+  // The element size in this array
+  private int elementSize;
+
+  private int headerInBytes;
+
+  private void assertIndexIsValid(int index) {
+    assert index >= 0 : "index (" + index + ") should >= 0";
+    assert index < numElements : "index (" + index + ") should < " + numElements;
+  }
+
+  public GrowableArrayWriter(UnsafeWriter writer, int elementSize) {
+    super(writer.getBufferHolder());
+    this.elementSize = elementSize;
+  }
+
+  public void initialize(int numElements) {
+    // We need 8 bytes to store numElements in header
+    this.numElements = numElements;
+    this.headerInBytes = calculateHeaderPortionInBytes(numElements);
+
+    this.startingOffset = cursor();
+
+    // Grows the global buffer ahead for header and fixed size data.
+    int fixedPartInBytes =
+      ByteArrayMethods.roundNumberOfBytesToNearestWord(elementSize * numElements);
+    holder.grow(headerInBytes + fixedPartInBytes);
+
+    // Write numElements and clear out null bits to header
+    Platform.putLong(getBuffer(), startingOffset, numElements);
+    for (int i = 8; i < headerInBytes; i += 8) {
+      Platform.putLong(getBuffer(), startingOffset + i, 0L);
+    }
+
+    // fill 0 into reminder part of 8-bytes alignment in unsafe array
+    for (int i = elementSize * numElements; i < fixedPartInBytes; i++) {
+      Platform.putByte(getBuffer(), startingOffset + headerInBytes + i, (byte) 0);
+    }
+    increaseCursor(headerInBytes + fixedPartInBytes);
+  }
+
+  private long getElementOffset(int ordinal) {
+    return startingOffset + headerInBytes + ordinal * (long) elementSize;
+  }
+
+  private void setNullBit(int ordinal) {
+    assertIndexIsValid(ordinal);
+    BitSetMethods.set(getBuffer(), startingOffset + 8, ordinal);
+  }
+
+  @Override
+  public void setNull1Bytes(int ordinal) {
+    setNullBit(ordinal);
+    // put zero into the corresponding field when set null
+    writeByte(getElementOffset(ordinal), (byte)0);
+  }
+
+  @Override
+  public void setNull2Bytes(int ordinal) {
+    setNullBit(ordinal);
+    // put zero into the corresponding field when set null
+    writeShort(getElementOffset(ordinal), (short)0);
+  }
+
+  @Override
+  public void setNull4Bytes(int ordinal) {
+    setNullBit(ordinal);
+    // put zero into the corresponding field when set null
+    writeInt(getElementOffset(ordinal), 0);
+  }
+
+  @Override
+  public void setNull8Bytes(int ordinal) {
+    setNullBit(ordinal);
+    // put zero into the corresponding field when set null
+    writeLong(getElementOffset(ordinal), 0);
+  }
+
+  public void setNull(int ordinal) { setNull8Bytes(ordinal); }
+
+  @Override
+  public void write(int ordinal, boolean value) {
+    assertIndexIsValid(ordinal);
+    writeBoolean(getElementOffset(ordinal), value);
+  }
+
+  @Override
+  public void write(int ordinal, byte value) {
+    assertIndexIsValid(ordinal);
+    writeByte(getElementOffset(ordinal), value);
+  }
+
+  @Override
+  public void write(int ordinal, short value) {
+    assertIndexIsValid(ordinal);
+    writeShort(getElementOffset(ordinal), value);
+  }
+
+  @Override
+  public void write(int ordinal, int value) {
+    assertIndexIsValid(ordinal);
+    writeInt(getElementOffset(ordinal), value);
+  }
+
+  @Override
+  public void write(int ordinal, long value) {
+    assertIndexIsValid(ordinal);
+    writeLong(getElementOffset(ordinal), value);
+  }
+
+  @Override
+  public void write(int ordinal, float value) {
+    assertIndexIsValid(ordinal);
+    writeFloat(getElementOffset(ordinal), value);
+  }
+
+  @Override
+  public void write(int ordinal, double value) {
+    assertIndexIsValid(ordinal);
+    writeDouble(getElementOffset(ordinal), value);
+  }
+
+  @Override
+  public void write(int ordinal, Decimal input, int precision, int scale) {
+    // make sure Decimal object has the same scale as DecimalType
+    assertIndexIsValid(ordinal);
+    if (input != null && input.changePrecision(precision, scale)) {
+      if (precision <= Decimal.MAX_LONG_DIGITS()) {
+        write(ordinal, input.toUnscaledLong());
+      } else {
+        final byte[] bytes = input.toJavaBigDecimal().unscaledValue().toByteArray();
+        final int numBytes = bytes.length;
+        assert numBytes <= 16;
+        int roundedSize = ByteArrayMethods.roundNumberOfBytesToNearestWord(numBytes);
+        grow(roundedSize);
+
+        zeroOutPaddingBytes(numBytes);
+
+        // Write the bytes to the variable length portion.
+        Platform.copyMemory(
+          bytes, Platform.BYTE_ARRAY_OFFSET, getBuffer(), cursor(), numBytes);
+        setOffsetAndSize(ordinal, numBytes);
+
+        // move the cursor forward with 8-bytes boundary
+        increaseCursor(roundedSize);
+      }
+    } else {
+      setNull(ordinal);
+    }
+  }
+}

--- a/core/src/main/java/fastproto/GrowableArrayWriter.java
+++ b/core/src/main/java/fastproto/GrowableArrayWriter.java
@@ -31,156 +31,158 @@ import static org.apache.spark.sql.catalyst.expressions.UnsafeArrayData.calculat
  */
 public final class GrowableArrayWriter extends UnsafeWriter {
 
-  // The number of elements in this array
-  private int numElements;
+    // The number of elements in this array
+    private int numElements;
 
-  // The element size in this array
-  private int elementSize;
+    // The element size in this array
+    private int elementSize;
 
-  private int headerInBytes;
+    private int headerInBytes;
 
-  private void assertIndexIsValid(int index) {
-    assert index >= 0 : "index (" + index + ") should >= 0";
-    assert index < numElements : "index (" + index + ") should < " + numElements;
-  }
-
-  public GrowableArrayWriter(UnsafeWriter writer, int elementSize) {
-    super(writer.getBufferHolder());
-    this.elementSize = elementSize;
-  }
-
-  public void initialize(int numElements) {
-    // We need 8 bytes to store numElements in header
-    this.numElements = numElements;
-    this.headerInBytes = calculateHeaderPortionInBytes(numElements);
-
-    this.startingOffset = cursor();
-
-    // Grows the global buffer ahead for header and fixed size data.
-    int fixedPartInBytes =
-      ByteArrayMethods.roundNumberOfBytesToNearestWord(elementSize * numElements);
-    holder.grow(headerInBytes + fixedPartInBytes);
-
-    // Write numElements and clear out null bits to header
-    Platform.putLong(getBuffer(), startingOffset, numElements);
-    for (int i = 8; i < headerInBytes; i += 8) {
-      Platform.putLong(getBuffer(), startingOffset + i, 0L);
+    private void assertIndexIsValid(int index) {
+        assert index >= 0 : "index (" + index + ") should >= 0";
+        assert index < numElements : "index (" + index + ") should < " + numElements;
     }
 
-    // fill 0 into reminder part of 8-bytes alignment in unsafe array
-    for (int i = elementSize * numElements; i < fixedPartInBytes; i++) {
-      Platform.putByte(getBuffer(), startingOffset + headerInBytes + i, (byte) 0);
+    public GrowableArrayWriter(UnsafeWriter writer, int elementSize) {
+        super(writer.getBufferHolder());
+        this.elementSize = elementSize;
     }
-    increaseCursor(headerInBytes + fixedPartInBytes);
-  }
 
-  private long getElementOffset(int ordinal) {
-    return startingOffset + headerInBytes + ordinal * (long) elementSize;
-  }
+    public void initialize(int numElements) {
+        // We need 8 bytes to store numElements in header
+        this.numElements = numElements;
+        this.headerInBytes = calculateHeaderPortionInBytes(numElements);
 
-  private void setNullBit(int ordinal) {
-    assertIndexIsValid(ordinal);
-    BitSetMethods.set(getBuffer(), startingOffset + 8, ordinal);
-  }
+        this.startingOffset = cursor();
 
-  @Override
-  public void setNull1Bytes(int ordinal) {
-    setNullBit(ordinal);
-    // put zero into the corresponding field when set null
-    writeByte(getElementOffset(ordinal), (byte)0);
-  }
+        // Grows the global buffer ahead for header and fixed size data.
+        int fixedPartInBytes =
+                ByteArrayMethods.roundNumberOfBytesToNearestWord(elementSize * numElements);
+        grow(headerInBytes + fixedPartInBytes);
 
-  @Override
-  public void setNull2Bytes(int ordinal) {
-    setNullBit(ordinal);
-    // put zero into the corresponding field when set null
-    writeShort(getElementOffset(ordinal), (short)0);
-  }
+        // Write numElements and clear out null bits to header
+        Platform.putLong(getBuffer(), startingOffset, numElements);
+        for (int i = 8; i < headerInBytes; i += 8) {
+            Platform.putLong(getBuffer(), startingOffset + i, 0L);
+        }
 
-  @Override
-  public void setNull4Bytes(int ordinal) {
-    setNullBit(ordinal);
-    // put zero into the corresponding field when set null
-    writeInt(getElementOffset(ordinal), 0);
-  }
-
-  @Override
-  public void setNull8Bytes(int ordinal) {
-    setNullBit(ordinal);
-    // put zero into the corresponding field when set null
-    writeLong(getElementOffset(ordinal), 0);
-  }
-
-  public void setNull(int ordinal) { setNull8Bytes(ordinal); }
-
-  @Override
-  public void write(int ordinal, boolean value) {
-    assertIndexIsValid(ordinal);
-    writeBoolean(getElementOffset(ordinal), value);
-  }
-
-  @Override
-  public void write(int ordinal, byte value) {
-    assertIndexIsValid(ordinal);
-    writeByte(getElementOffset(ordinal), value);
-  }
-
-  @Override
-  public void write(int ordinal, short value) {
-    assertIndexIsValid(ordinal);
-    writeShort(getElementOffset(ordinal), value);
-  }
-
-  @Override
-  public void write(int ordinal, int value) {
-    assertIndexIsValid(ordinal);
-    writeInt(getElementOffset(ordinal), value);
-  }
-
-  @Override
-  public void write(int ordinal, long value) {
-    assertIndexIsValid(ordinal);
-    writeLong(getElementOffset(ordinal), value);
-  }
-
-  @Override
-  public void write(int ordinal, float value) {
-    assertIndexIsValid(ordinal);
-    writeFloat(getElementOffset(ordinal), value);
-  }
-
-  @Override
-  public void write(int ordinal, double value) {
-    assertIndexIsValid(ordinal);
-    writeDouble(getElementOffset(ordinal), value);
-  }
-
-  @Override
-  public void write(int ordinal, Decimal input, int precision, int scale) {
-    // make sure Decimal object has the same scale as DecimalType
-    assertIndexIsValid(ordinal);
-    if (input != null && input.changePrecision(precision, scale)) {
-      if (precision <= Decimal.MAX_LONG_DIGITS()) {
-        write(ordinal, input.toUnscaledLong());
-      } else {
-        final byte[] bytes = input.toJavaBigDecimal().unscaledValue().toByteArray();
-        final int numBytes = bytes.length;
-        assert numBytes <= 16;
-        int roundedSize = ByteArrayMethods.roundNumberOfBytesToNearestWord(numBytes);
-        grow(roundedSize);
-
-        zeroOutPaddingBytes(numBytes);
-
-        // Write the bytes to the variable length portion.
-        Platform.copyMemory(
-          bytes, Platform.BYTE_ARRAY_OFFSET, getBuffer(), cursor(), numBytes);
-        setOffsetAndSize(ordinal, numBytes);
-
-        // move the cursor forward with 8-bytes boundary
-        increaseCursor(roundedSize);
-      }
-    } else {
-      setNull(ordinal);
+        // fill 0 into reminder part of 8-bytes alignment in unsafe array
+        for (int i = elementSize * numElements; i < fixedPartInBytes; i++) {
+            Platform.putByte(getBuffer(), startingOffset + headerInBytes + i, (byte) 0);
+        }
+        increaseCursor(headerInBytes + fixedPartInBytes);
     }
-  }
+
+    private long getElementOffset(int ordinal) {
+        return startingOffset + headerInBytes + ordinal * (long) elementSize;
+    }
+
+    private void setNullBit(int ordinal) {
+        assertIndexIsValid(ordinal);
+        BitSetMethods.set(getBuffer(), startingOffset + 8, ordinal);
+    }
+
+    @Override
+    public void setNull1Bytes(int ordinal) {
+        setNullBit(ordinal);
+        // put zero into the corresponding field when set null
+        writeByte(getElementOffset(ordinal), (byte) 0);
+    }
+
+    @Override
+    public void setNull2Bytes(int ordinal) {
+        setNullBit(ordinal);
+        // put zero into the corresponding field when set null
+        writeShort(getElementOffset(ordinal), (short) 0);
+    }
+
+    @Override
+    public void setNull4Bytes(int ordinal) {
+        setNullBit(ordinal);
+        // put zero into the corresponding field when set null
+        writeInt(getElementOffset(ordinal), 0);
+    }
+
+    @Override
+    public void setNull8Bytes(int ordinal) {
+        setNullBit(ordinal);
+        // put zero into the corresponding field when set null
+        writeLong(getElementOffset(ordinal), 0);
+    }
+
+    public void setNull(int ordinal) {
+        setNull8Bytes(ordinal);
+    }
+
+    @Override
+    public void write(int ordinal, boolean value) {
+        assertIndexIsValid(ordinal);
+        writeBoolean(getElementOffset(ordinal), value);
+    }
+
+    @Override
+    public void write(int ordinal, byte value) {
+        assertIndexIsValid(ordinal);
+        writeByte(getElementOffset(ordinal), value);
+    }
+
+    @Override
+    public void write(int ordinal, short value) {
+        assertIndexIsValid(ordinal);
+        writeShort(getElementOffset(ordinal), value);
+    }
+
+    @Override
+    public void write(int ordinal, int value) {
+        assertIndexIsValid(ordinal);
+        writeInt(getElementOffset(ordinal), value);
+    }
+
+    @Override
+    public void write(int ordinal, long value) {
+        assertIndexIsValid(ordinal);
+        writeLong(getElementOffset(ordinal), value);
+    }
+
+    @Override
+    public void write(int ordinal, float value) {
+        assertIndexIsValid(ordinal);
+        writeFloat(getElementOffset(ordinal), value);
+    }
+
+    @Override
+    public void write(int ordinal, double value) {
+        assertIndexIsValid(ordinal);
+        writeDouble(getElementOffset(ordinal), value);
+    }
+
+    @Override
+    public void write(int ordinal, Decimal input, int precision, int scale) {
+        // make sure Decimal object has the same scale as DecimalType
+        assertIndexIsValid(ordinal);
+        if (input != null && input.changePrecision(precision, scale)) {
+            if (precision <= Decimal.MAX_LONG_DIGITS()) {
+                write(ordinal, input.toUnscaledLong());
+            } else {
+                final byte[] bytes = input.toJavaBigDecimal().unscaledValue().toByteArray();
+                final int numBytes = bytes.length;
+                assert numBytes <= 16;
+                int roundedSize = ByteArrayMethods.roundNumberOfBytesToNearestWord(numBytes);
+                grow(roundedSize);
+
+                zeroOutPaddingBytes(numBytes);
+
+                // Write the bytes to the variable length portion.
+                Platform.copyMemory(
+                        bytes, Platform.BYTE_ARRAY_OFFSET, getBuffer(), cursor(), numBytes);
+                setOffsetAndSize(ordinal, numBytes);
+
+                // move the cursor forward with 8-bytes boundary
+                increaseCursor(roundedSize);
+            }
+        } else {
+            setNull(ordinal);
+        }
+    }
 }

--- a/core/src/main/java/fastproto/IntList.java
+++ b/core/src/main/java/fastproto/IntList.java
@@ -4,11 +4,8 @@ package fastproto;
  * Efficient growable int array for packed repeated field parsing.
  * Uses public fields for performance and direct access in generated code.
  */
-public class IntList {
+public class IntList extends FastList {
     public int[] array;
-    public int count;
-
-    private static final int DEFAULT_CAPACITY = 10;
 
     public IntList() {
         this.array = new int[DEFAULT_CAPACITY];

--- a/core/src/main/java/fastproto/LongList.java
+++ b/core/src/main/java/fastproto/LongList.java
@@ -4,11 +4,8 @@ package fastproto;
  * Efficient growable long array for packed repeated field parsing.
  * Uses public fields for performance and direct access in generated code.
  */
-public class LongList {
+public class LongList extends FastList {
     public long[] array;
-    public int count;
-
-    private static final int DEFAULT_CAPACITY = 10;
 
     public LongList() {
         this.array = new long[DEFAULT_CAPACITY];

--- a/core/src/main/java/fastproto/NullDefaultRowWriter.java
+++ b/core/src/main/java/fastproto/NullDefaultRowWriter.java
@@ -259,6 +259,7 @@ public final class NullDefaultRowWriter extends AbstractRowWriter implements Row
         // clearNullBit(ordinal); // this is not needed
     }
 
+
     /**
      * Writes a UTF8String and automatically clears the null bit.
      * This wraps the final write(int, UTF8String) method from parent class with automatic null bit clearing
@@ -289,4 +290,5 @@ public final class NullDefaultRowWriter extends AbstractRowWriter implements Row
         setOffsetAndSizeFromPreviousCursor(ordinal, previousCursor);
         // clearNullBit(ordinal); // this is not needed
     }
+
 }

--- a/core/src/main/java/fastproto/ObjectList.java
+++ b/core/src/main/java/fastproto/ObjectList.java
@@ -1,15 +1,11 @@
 package fastproto;
 
 /**
- * Efficient growable byte array list for repeated string/bytes/message field parsing.
+ * Efficient growable object list for repeated field parsing.
  * Uses public fields for performance and direct access in generated code.
- * Each element is a byte array representing a string, bytes field, or serialized message.
  */
-public abstract class ObjectList<T> {
+public abstract class ObjectList<T> extends FastList {
     public T[] array;
-    public int count;
-
-    protected static final int DEFAULT_CAPACITY = 10;
 
     protected abstract T[] newArray(int len);
 
@@ -51,8 +47,8 @@ public abstract class ObjectList<T> {
     }
 
     /**
-     * Add a single byte array to the list, growing if necessary.
-     * Used for repeated string/bytes/message field values.
+     * Add a single object to the list, growing if necessary.
+     * Used for repeated field values.
      */
     public void add(T value) {
         if (count >= array.length) {

--- a/core/src/main/java/fastproto/ObjectList.java
+++ b/core/src/main/java/fastproto/ObjectList.java
@@ -9,13 +9,21 @@ public abstract class ObjectList<T> {
     public T[] array;
     public int count;
 
-    private static final int DEFAULT_CAPACITY = 10;
+    protected static final int DEFAULT_CAPACITY = 10;
 
     protected abstract T[] newArray(int len);
 
     public ObjectList() {
         this.array = newArray(DEFAULT_CAPACITY);
         this.count = 0;
+    }
+
+    protected ObjectList(boolean initialize) {
+        if (initialize) {
+            this.array = newArray(DEFAULT_CAPACITY);
+            this.count = 0;
+        }
+        // Otherwise, subclass will initialize manually
     }
 
     /**

--- a/core/src/main/scala/fastproto/WireFormatParser.scala
+++ b/core/src/main/scala/fastproto/WireFormatParser.scala
@@ -618,15 +618,8 @@ object WireFormatParser {
           case _ => throw new IllegalArgumentException(s"Expected StructType or ArrayType[StructType] for message field ${mapping.fieldDescriptor.getName}")
         }
 
-        // Check if we have a ParserRef already (handles cycles)
-        visited.get(nestedKey) match {
-          case Some(existingRef) =>
-            // Use existing ParserRef (may have null parser if being built)
-            parsersArray(i) = existingRef
-          case None =>
-            // Build child parser (returns ParserRef)
-            parsersArray(i) = buildOptimizedParser(nestedDescriptor, nestedSchema, recursiveTypes, visited)
-        }
+        // Build child parser (buildOptimizedParser handles existing ParserRef in visited map)
+        parsersArray(i) = buildOptimizedParser(nestedDescriptor, nestedSchema, recursiveTypes, visited)
       }
       i += 1
     }

--- a/core/src/main/scala/fastproto/WireFormatParser.scala
+++ b/core/src/main/scala/fastproto/WireFormatParser.scala
@@ -6,6 +6,7 @@ import fastproto.StreamWireParser._
 import org.apache.spark.sql.types.{ArrayType, StructType}
 
 import java.nio.ByteBuffer
+import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 

--- a/core/src/main/scala/fastproto/WireFormatParser.scala
+++ b/core/src/main/scala/fastproto/WireFormatParser.scala
@@ -6,7 +6,6 @@ import fastproto.StreamWireParser._
 import org.apache.spark.sql.types.{ArrayType, StructType}
 
 import java.nio.ByteBuffer
-import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
@@ -114,7 +113,6 @@ class WireFormatParser(
 
     (mappingArray, maxFieldNum, typesArray)
   }
-
 
 
   private def buildNestedParsersArray(): Array[ParserRef] = {
@@ -622,7 +620,6 @@ object WireFormatParser {
 
     parsersArray
   }
-
 
 
   private def buildFieldMappingArrayForDescriptor(descriptor: Descriptor, schema: StructType): Array[FieldMapping] = {

--- a/core/src/main/scala/fastproto/WireFormatParser.scala
+++ b/core/src/main/scala/fastproto/WireFormatParser.scala
@@ -538,13 +538,13 @@ object WireFormatParser {
     def reset(): Unit = {
       var i = 0
       while (i <= maxFieldNumber) {
-        if (intLists(i) != null) intLists(i).count = 0
-        if (longLists(i) != null) longLists(i).count = 0
-        if (floatLists(i) != null) floatLists(i).count = 0
-        if (doubleLists(i) != null) doubleLists(i).count = 0
-        if (booleanLists(i) != null) booleanLists(i).count = 0
-        if (bytesLists(i) != null) bytesLists(i).count = 0
-        if (bufferLists(i) != null) bufferLists(i).count = 0
+        if (intLists(i) != null) intLists(i).reset()
+        if (longLists(i) != null) longLists(i).reset()
+        if (floatLists(i) != null) floatLists(i).reset()
+        if (doubleLists(i) != null) doubleLists(i).reset()
+        if (booleanLists(i) != null) booleanLists(i).reset()
+        if (bytesLists(i) != null) bytesLists(i).reset()
+        if (bufferLists(i) != null) bufferLists(i).reset()
         i += 1
       }
     }

--- a/core/src/main/scala/fastproto/WireFormatParser.scala
+++ b/core/src/main/scala/fastproto/WireFormatParser.scala
@@ -127,7 +127,7 @@ class WireFormatParser(
 
       // String/Bytes types use BytesList, Message types use GenericList[ByteBuffer]
       case STRING | BYTES => new BytesList()
-      case MESSAGE => new GenericList[ByteBuffer]()
+      case MESSAGE => new GenericList(classOf[java.nio.ByteBuffer])
 
       case GROUP => throw new UnsupportedOperationException("GROUP type is deprecated and not supported")
     }

--- a/core/src/main/scala/fastproto/WireFormatParser.scala
+++ b/core/src/main/scala/fastproto/WireFormatParser.scala
@@ -613,11 +613,11 @@ object WireFormatParser {
 
         // Check if this would create a cycle (same descriptor being built non-recursively)
         val nonRecursiveKey = (nestedKey, false)
-        if (!isRecursive && visited.contains(nonRecursiveKey)) {
-          // Cycle detected! Create recursive version
+        if (!isRecursive && visited.get(nonRecursiveKey).exists(_.parser == null)) {
+          // Cycle detected! The ParserRef exists but parser is null (currently being built)
           parsersArray(i) = buildOptimizedParser(nestedDescriptor, nestedSchema, isRecursive = true, visited)
         } else {
-          // Build child parser with same recursion flag
+          // Build child parser with same recursion flag (will reuse if already complete)
           parsersArray(i) = buildOptimizedParser(nestedDescriptor, nestedSchema, isRecursive, visited)
         }
       }

--- a/core/src/main/scala/fastproto/WireFormatToRowGenerator.scala
+++ b/core/src/main/scala/fastproto/WireFormatToRowGenerator.scala
@@ -100,7 +100,7 @@ object WireFormatToRowGenerator {
       case FLOAT => "readFloat"
       case DOUBLE => "readDouble"
       case BOOL => "readBool"
-      case STRING | BYTES | MESSAGE => "readByteArray"
+      case STRING | BYTES | MESSAGE => "readByteBuffer"
       case ENUM => "readEnum"
     }
   }
@@ -150,7 +150,7 @@ object WireFormatToRowGenerator {
       case FLOAT => "resizeFloatArray"
       case DOUBLE => "resizeDoubleArray"
       case BOOL => "resizeBooleanArray"
-      case t if isLengthDelimited(t) => "resizeByteArrayArray"
+      case t if isLengthDelimited(t) => "resizeByteBufferArray"
       case ENUM => "resizeIntArray"
       case _ => throw new IllegalArgumentException(s"Unknown type: $fieldType")
     }
@@ -167,9 +167,9 @@ object WireFormatToRowGenerator {
       case FLOAT => "writeFloatArray"
       case DOUBLE => "writeDoubleArray"
       case BOOL => "writeBooleanArray"
-      case STRING => "writeStringArray"
-      case BYTES => "writeBytesArray"
-      case MESSAGE => "writeMessageArray"
+      case STRING => "writeStringArrayFromBuffers"
+      case BYTES => "writeBytesArrayFromBuffers"
+      case MESSAGE => "writeMessageArrayFromBuffers"
       case ENUM => "writeIntArray"
       case _ => throw new IllegalArgumentException(s"Unsupported array type: $fieldType")
     }
@@ -371,6 +371,7 @@ object WireFormatToRowGenerator {
     code ++= "import org.apache.spark.unsafe.types.UTF8String;\n"
     code ++= "import fastproto.StreamWireParser;\n"
     code ++= "import java.io.IOException;\n"
+    code ++= "import java.nio.ByteBuffer;\n"
     code ++= "import fastproto.IntList;\n"
     code ++= "import fastproto.LongList;\n\n"
 
@@ -520,7 +521,8 @@ object WireFormatToRowGenerator {
             val javaType = getJavaElementType(field.getType)
             val initialCapacity = getInitialCapacity(field.getType)
             // For primitive types, javaType is "int", "long", etc. -> new int[8]
-            // For byte array types, javaType is "byte[]" -> new byte[8][]
+            // For ByteBuffer types, javaType is "ByteBuffer" -> new ByteBuffer[8]
+            // For byte array types (old code), javaType was "byte[]" -> new byte[8][]
             if (javaType.endsWith("[]")) {
               val baseType = javaType.dropRight(2)
               code ++= s"    field${field.getNumber}_values = new $baseType[$initialCapacity][];\n"
@@ -556,9 +558,11 @@ object WireFormatToRowGenerator {
           } else {
             val javaType = getJavaElementType(field.getType)
             val initialCapacity = getInitialCapacity(field.getType)
+            // For primitive types, javaType is "int", "long", etc. -> int[] field_values = new int[8]
+            // For ByteBuffer types, javaType is "ByteBuffer" -> ByteBuffer[] field_values = new ByteBuffer[8]
+            // For byte array types (old code), javaType was "byte[]" -> byte[][] field_values = new byte[8][]
             if (javaType.endsWith("[]")) {
-              // For byte array types: javaType is "byte[]", we want "byte[][]" for the variable
-              val baseType = javaType.dropRight(2)  // "byte"
+              val baseType = javaType.dropRight(2)
               code ++= s"    $javaType[] field${fieldNum}_values = new $baseType[$initialCapacity][];\n"
             } else {
               code ++= s"    $javaType[] field${fieldNum}_values = new $javaType[$initialCapacity];\n"
@@ -672,9 +676,9 @@ object WireFormatToRowGenerator {
       case FieldDescriptor.Type.BOOL =>
         code ++= s"            writer.write($ordinal, input.readBool());\n"
       case FieldDescriptor.Type.STRING =>
-        code ++= s"            writer.writeBytes($ordinal, input.readByteArray());\n"
+        code ++= s"            writer.writeBytes($ordinal, input.readByteBuffer());\n"
       case FieldDescriptor.Type.BYTES =>
-        code ++= s"            writer.writeBytes($ordinal, input.readByteArray());\n"
+        code ++= s"            writer.writeBytes($ordinal, input.readByteBuffer());\n"
       case FieldDescriptor.Type.ENUM =>
         // Check schema to determine if enum should be written as integer or string
         val enumField = schema.fields(ordinal)
@@ -687,12 +691,12 @@ object WireFormatToRowGenerator {
             throw new IllegalArgumentException(s"Unsupported enum target type: $other")
         }
       case FieldDescriptor.Type.MESSAGE =>
-        code ++= s"            byte[] messageBytes${fieldNum} = input.readByteArray();\n"
+        code ++= s"            ByteBuffer messageBuffer${fieldNum} = input.readByteBuffer();\n"
         code ++= s"            if (nestedConv${fieldNum} != null) {\n"
         code ++= s"              int offset = writer.cursor();\n"
         code ++= s"              RowWriter nestedWriter = nestedConv${fieldNum}.acquireNestedWriter(writer);\n"
         code ++= s"              nestedWriter.resetRowWriter();\n"
-        code ++= s"              nestedConv${fieldNum}.parseInto(messageBytes${fieldNum}, nestedWriter);\n"
+        code ++= s"              nestedConv${fieldNum}.parseInto(messageBuffer${fieldNum}, nestedWriter);\n"
         code ++= s"              writer.writeVariableField($ordinal, offset);\n"
         code ++= s"            }\n"
       case _ =>
@@ -866,7 +870,7 @@ object WireFormatToRowGenerator {
       case FLOAT => "float"
       case DOUBLE => "double"
       case BOOL => "boolean"
-      case STRING | BYTES | MESSAGE => "byte[]"
+      case STRING | BYTES | MESSAGE => "ByteBuffer"
       case _ => throw new UnsupportedOperationException(s"Unsupported array type: $fieldType")
     }
   }

--- a/core/src/main/scala/fastproto/WireFormatToRowGenerator.scala
+++ b/core/src/main/scala/fastproto/WireFormatToRowGenerator.scala
@@ -576,7 +576,7 @@ object WireFormatToRowGenerator {
         repeatedFields.foreach { field =>
           val fieldNum = field.getNumber
           if (isVarint32(field.getType) || isVarint64(field.getType)) {
-            code ++= s"    field${fieldNum}_list.count = 0;\n"
+            code ++= s"    field${fieldNum}_list.reset();\n"
           } else {
             code ++= s"    field${fieldNum}_count = 0;\n"
           }


### PR DESCRIPTION
## Summary

This PR adds recursive type support and zero-copy optimizations to WireFormatParser:

- **Recursive type support**: Enables parsing of protobuf messages with self-referential types (e.g., `message Node { repeated Node children; }`)
- **Zero-copy nested messages**: Uses ByteBuffer views instead of copying bytes for nested message fields
- **Thread-safe ParseState**: Refactored to use local state accumulation for recursive parsing
- **Cycle detection**: Single-phase parser construction with dual versioning to detect circular dependencies
- **GrowableArrayWriter**: New writer for efficiently handling variable-sized repeated message fields
- **BufferList specialization**: Dedicated list type for ByteBuffer to eliminate generic overhead

## Key Changes

- `WireFormatParser.scala`: Added recursive parsing with ParseState, cycle detection, and ByteBuffer support
- `StreamWireParser.java`: Added `parseInto(ByteBuffer, RowWriter)` and `writeMessageArrayFromBuffers()` methods
- `GrowableArrayWriter.java`: New writer for variable-sized array accumulation
- `BufferList.java`: Specialized list for ByteBuffer (MESSAGE fields)
- `GenericList.java`: Generic fallback for object lists using reflection
- `FastList.java`: Added `reset()` method for state reuse
- Updated all list classes to extend FastList for unified interface

## Testing

- Compiles successfully: `sbt --error "core/compile"`
- Existing tests pass (recursive type tests enabled)
- Benchmarks verify performance characteristics

## Dependencies

Builds on PR #28 (infrastructure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>